### PR TITLE
Update Twig version to 1.26.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "symfony/translation": "~2.8",
         "symfony/yaml": "~2.8",
         "symfony/event-dispatcher": "~2.8",
-        "twig/twig": "1.23.1"
+        "twig/twig": "^1.23.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "74343d9ac5798c741038ebc92219bc72",
-    "content-hash": "d3ed03e1e23a5ce70bbb90ab3257ec01",
+    "hash": "063e319e3f60eea42bf98734c82444ea",
+    "content-hash": "459803a9d76abeceab85453f282dbc13",
     "packages": [
         {
             "name": "dflydev/dot-access-configuration",
@@ -829,16 +829,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6"
+                "reference": "81c2b5fd36581370c7731387f05dcdb577050513"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
-                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/81c2b5fd36581370c7731387f05dcdb577050513",
+                "reference": "81c2b5fd36581370c7731387f05dcdb577050513",
                 "shasum": ""
             },
             "require": {
@@ -851,7 +851,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.23-dev"
+                    "dev-master": "1.26-dev"
                 }
             },
             "autoload": {
@@ -886,7 +886,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-11-05 12:49:06"
+            "time": "2016-10-02 16:19:13"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Fix normalizePath: Do not mangle phar URLs.
https://github.com/twigphp/Twig/pull/2152