### PR TITLE
added «query» option for executing directly via option SQL sentences …

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -1,5 +1,5 @@
 services:
-  # DrupalConsoleCore Services
+  # DrupalConsoleCore SerDrupalConsoleCorevices
   console.translator_manager:
     class: Drupal\Console\Utils\TranslatorManager
   console.configuration_manager:


### PR DESCRIPTION
…when using database:client
added «query» option for executing directly via option SQL sentences when using database:client
related to https://github.com/hechoendrupal/DrupalConsole/issues/2859
related to https://github.com/hechoendrupal/DrupalConsole/pull/2860
