### PR TITLE
Nested chains not running

### DIFF
--- a/src/Command/Chain/ChainCommand.php
+++ b/src/Command/Chain/ChainCommand.php
@@ -11,6 +11,7 @@ use Dflydev\PlaceholderResolver\DataSource\ArrayDataSource;
 use Dflydev\PlaceholderResolver\RegexPlaceholderResolver;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
@@ -312,12 +313,20 @@ class ChainCommand extends Command
                 }
             }
 
-            $this->chainQueue->addCommand(
-                $command['command'],
-                $moduleInputs,
-                $interactive,
-                $learning
-            );
+            $application = $this->getApplication();
+            $callCommand = $application->find($command['command']);
+
+            if (!$callCommand) {
+                continue;
+            }
+
+            $input = new ArrayInput($moduleInputs);
+            if (!is_null($interactive)) {
+              $input->setInteractive($interactive);
+            }
+
+            $io->text($command['command']);
+            $callCommand->run($input, $io);
         }
 
         return 0;


### PR DESCRIPTION
We are having problems running chains that call other chains. I believe this is because the `ConsoleEvents::TERMINATE` event is only fired once, which means the CallCommandListener only calls the top level chains in the ChainQueue.

I have updated the code to call commands directly rather than add them to the ChainQueue as this fixes the issue, however, it doesn't seem to be the correct approach.

I think you will have a better understanding of the issue and may be able to get this working with the CallCommandListener processing ChainQueue.

**Here is an example of chains being nested:**
`drupal test:main`

chain-test-main.yml
```
command:
  name: test:main
  description: 'Example of a chain calling another chain with placeholders'
commands:
  - command: test:child
    options:
      placeholder:
        - 'project:%{{project|main-project}}'
        - 'directory:main-dir'
```

chain-test-child.yml
```
command:
  name: test:child
  description: 'Example of chain that is called by another chain'
commands:
  - command: exec
    arguments:
      bin: 'echo "This is a test: Project:%{{project|foo}} Directory:%{{directory|bar}}"'
```