### PR TITLE
Bump minimum version of webflo/drupal-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "symfony/yaml": ">=2.7 <3.0",
         "symfony/event-dispatcher": ">=2.7 <3.0",
         "twig/twig": "^1.23.1",
-        "webflo/drupal-finder": "0.*"
+        "webflo/drupal-finder": "^0.3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e41996437ebeca9288ddc546b12e6b06",
+    "content-hash": "4785a39112df2196b610395418ace928",
     "packages": [
         {
             "name": "dflydev/dot-access-configuration",


### PR DESCRIPTION
0.3.0 is the minimum version because of the new vendorDir method.