### PR TITLE
Fixing chain translation typo

### DIFF
--- a/src/Command/Chain/ChainCommand.php
+++ b/src/Command/Chain/ChainCommand.php
@@ -149,7 +149,7 @@ class ChainCommand extends Command
                         $inlinePlaceHolder,
                         $io->ask(
                             sprintf(
-                                $this->trans('commands.chain.message.enter-value-for-placeholder'),
+                                $this->trans('commands.chain.messages.enter-value-for-placeholder'),
                                 $inlinePlaceHolder
                             ),
                             $inlinePlaceHolderValue


### PR DESCRIPTION
I noticed chain placeholder messages were not displaying correctly due to typo in `ChainCommand.php`, e.g:
`commands.chain.message.enter-value-for-placeholder:`
was displaying instead of expected:
`Enter value for name placeholder:`
