### PR TITLE
Get the environment from config.yml if available

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -251,12 +251,19 @@ class Application extends BaseApplication
      */
     private function addOptions()
     {
+        // Get the configuration from config.yml.
+        $env = $this->container
+          ->get('console.configuration_manager')
+          ->getConfiguration()
+          ->get('application.environment');
+
         $this->getDefinition()->addOption(
             new InputOption(
                 '--env',
                 '-e',
                 InputOption::VALUE_OPTIONAL,
-                $this->trans('application.options.env'), 'prod'
+                $this->trans('application.options.env'),
+                !empty($env) ? $env : 'prod'
             )
         );
         $this->getDefinition()->addOption(


### PR DESCRIPTION
I am having a little problem when running commands on a dev environment.
I followed the instruction in https://hechoendrupal.gitbooks.io/drupal-console/content/en/commands/settings-set.html and run
`drupal settings:set environment dev`

When I view the contents of ~/.console/config.yml I see:
```application:
    environment: dev
```
When I run `drupal settings:debug`
I get
```
 Config file : /Users/marcelovani/.console/config.yml

 Config key                                          Config value
 language                                            en
 environment                                         dev
```

So far, so good, but when I am on a dev environment, I would like all the commands to assume the --env option as dev, as per config. Likewise, if I am on stage, the default option should be that.

I have made a little change, to pull the settings from from config.
That should change the default option to whatever environment we are.
We still can override the environment by passing the --env option.
If there is no config, it will assume `prod` as it was before this PR.

I hope what I am suggesting makes sense.