### PR TITLE
Comment out application.editor config by default

### DIFF
--- a/templates/core/init/config.yml.twig
+++ b/templates/core/init/config.yml.twig
@@ -1,7 +1,7 @@
 application:
   environment: 'prod'
   language: '{{language}}'
-  editor: 'vim'
+#  editor: 'vim'
   temp: '{{temp}}'
   develop: 'false'
   command: 'about'


### PR DESCRIPTION
This prevents overriding EDITOR from the user's environment if it is set


hechoendrupal/drupal-console#1401
hechoendrupal/drupal-console#3483