### PR TITLE
Changed stability to dev

### DIFF
--- a/config/chain/site-new.yml
+++ b/config/chain/site-new.yml
@@ -15,4 +15,4 @@ commands:
   # Create Drupal project using Composer
   - command: exec
     arguments:
-      bin: composer create-project {{repository}} {{directory}} --prefer-dist --no-progress --no-interaction
+      bin: composer create-project {{repository}} {{directory}} --stability dev --prefer-dist --no-progress --no-interaction


### PR DESCRIPTION
This fixes the error
```
  [InvalidArgumentException]
  Could not find package weknowinc/drupal-project with stability stable.
```
when running

`composer create-project weknowinc/drupal-project /Users/marcelovani/Sites/weknowinc-site --prefer-dist`