### PR TITLE
[generate-inline] Use | to separate array values

### DIFF
--- a/src/EventSubscriber/ShowGenerateInlineListener.php
+++ b/src/EventSubscriber/ShowGenerateInlineListener.php
@@ -116,7 +116,7 @@ class ShowGenerateInlineListener implements EventSubscriberInterface
                     foreach ($optionValue as $optionItem) {
                         if (is_array($optionItem)) {
                             $inlineValue = implode(
-                                ', ', array_map(
+                                ' | ', array_map(
                                     function ($v, $k) {
                                         return '"'.$k . '":"' . $v . '"';
                                     },


### PR DESCRIPTION
We use pipe to display fields inline