### PR TITLE
[generate:site:alias] Add drupal console binary option

### DIFF
--- a/src/Command/Generate/SiteAliasCommand.php
+++ b/src/Command/Generate/SiteAliasCommand.php
@@ -47,6 +47,7 @@ class SiteAliasCommand extends Command
     private $extraOptions = [
         'ssh' => [
             'none' => '',
+            'tty' => '-tt',
             'vagrant' => '-o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
         ],
         'container' => [
@@ -130,6 +131,12 @@ class SiteAliasCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.site.alias.options.port')
+            )
+            ->addOption(
+                'drupal-console-binary',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.site.alias.options.drupal-console-binary')
             )
             ->addOption(
                 'extra-options',
@@ -232,6 +239,19 @@ class SiteAliasCommand extends Command
         }
 
         if ($type !== 'local') {
+            $drupalConsoleBinary = $input->getOption('drupal-console-binary');
+            if (!$drupalConsoleBinary) {
+
+                $drupalConsoleBinary = $this->getIo()->askEmpty(
+                    $this->trans(
+                        'commands.generate.site.alias.questions.drupal-console-binary'
+                    ),
+                    'drupal'
+                );
+
+                $input->setOption('drupal-console-binary', $drupalConsoleBinary);
+            }
+
             $extraOptions = $input->getOption('extra-options');
             if (!$extraOptions) {
                 $options = array_values($this->extraOptions[$type]);
@@ -308,6 +328,7 @@ class SiteAliasCommand extends Command
                 'environment' => $input->getOption('environment'),
                 'type' => $input->getOption('type'),
                 'extra_options' => $input->getOption('extra-options'),
+                'drupal_console_binary' => $input->getOption('drupal-console-binary'),
                 'root' => $input->getOption('composer-root'),
                 'uri' => $input->getOption('site-uri'),
                 'port' => $input->getOption('port'),

--- a/templates/core/sites/alias.yml.twig
+++ b/templates/core/sites/alias.yml.twig
@@ -10,9 +10,14 @@
 {% if user %}
   user: {{ user }}
 {% endif %}
-{% if uri %}
+{% if uri or drupal_console_binary %}
   options:
+{% if uri %}
     uri: {{ uri }}
+{% endif %}
+{% if drupal_console_binary %}
+    drupal-console-binary: {{ drupal_console_binary }}
+{% endif %}
 {% else %}
 #  options:
 {% endif %}


### PR DESCRIPTION
Added the option to customize the drupal console binary and also give the option to add tty

example to execute
```
      drupal generate:site:alias  \
        --name="demo"  \
        --environment="dev"  \
        --type="ssh" \
        --composer-root="/path/to/remote/project" \
        --site-uri="default" \
        --host="hostName/domain" \
        --user="userName" \
        --port="port" \
        --drupal-console-binary="drupal" \
        --extra-options="-tt" \
        --directory="/Users/hjuarez/drupalSq/console/"
```