### PR TITLE
Add Message to run 'composer require drupal/console-language'.

### DIFF
--- a/src/Utils/TranslatorManager.php
+++ b/src/Utils/TranslatorManager.php
@@ -103,6 +103,10 @@ class TranslatorManager implements TranslatorManagerInterface
         $language,
         $directoryRoot
     ) {
+        $output = new ConsoleOutput();
+        $input = new ArrayInput([]);
+        $io = new DrupalStyle($input, $output);
+        
         $coreLanguageDirectory =
             $directoryRoot .
             sprintf(
@@ -126,6 +130,12 @@ class TranslatorManager implements TranslatorManagerInterface
         if (!isset($languageDirectory)) {
             if ($language == 'en') {
               throw new \Exception('No languages found. Make sure you have installed a console language package in a supported directory');
+            }else{
+                $io->warning(
+                    sprintf(
+                        'Language not available please execute this command in order to get the language locally using composer, run composer require drupal/console-'.$language.''
+                    )
+                );
             }
             return $this->buildCoreLanguageDirectory('en', $directoryRoot);
         }


### PR DESCRIPTION
Display message to install language, run ```composer require drupal/console-language``` using current language installed.
run ```drupal list```
![2019-09-24_2047](https://user-images.githubusercontent.com/6983125/65562706-e40a6980-df0c-11e9-8159-08c4e45e4ea8.png)

Thank's