### PR TITLE
fixed install modules in develop:contribute

### DIFF
--- a/config/chain/develop-contribute.yml
+++ b/config/chain/develop-contribute.yml
@@ -20,7 +20,7 @@ commands:
       bin: drupal site:install standard --root={{drupal}} --db-type="sqlite" --no-interaction
   - command: exec
     arguments:
-      bin: drupal module:install rest taxonomy locale migrate simpletest breakpoint node views features --root={{drupal}}
+      bin: drupal module:install --root={{drupal}} rest taxonomy locale migrate simpletest breakpoint node views features
   - command: exec
     arguments:
-      bin: drupal develop:create:symlinks --code-directory={{code}} --root={{drupal}}
+      bin: drupal develop:create:symlinks --root={{drupal}} --code-directory={{code}}

--- a/config/chain/develop-contribute.yml
+++ b/config/chain/develop-contribute.yml
@@ -18,18 +18,9 @@ commands:
   - command: exec
     arguments:
       bin: drupal site:install standard --root={{drupal}} --db-type="sqlite" --no-interaction
-  - command: 'module:install'
+  - command: exec
     arguments:
-      module:
-        - rest
-        - taxonomy
-        - locale
-        - migrate
-        - simpletest
-        - breakpoint
-        - node
-        - views
-        - features
+      bin: drupal module:install rest taxonomy locale migrate simpletest breakpoint node views features --root={{drupal}}
   - command: exec
     arguments:
       bin: drupal develop:create:symlinks --code-directory={{code}} --root={{drupal}}


### PR DESCRIPTION
it's mandatory pass `root` option to `module:install` command
otherwise it can install the required modules for translating