### PR TITLE
Warning messages are hardly visible

### DIFF
--- a/src/Style/DrupalStyle.php
+++ b/src/Style/DrupalStyle.php
@@ -237,7 +237,7 @@ class DrupalStyle extends SymfonyStyle
      */
     public function warning($message)
     {
-        $this->block($message, 'WARNING', 'fg=white;bg=yellow', ' ', true);
+        $this->block($message, 'WARNING', 'fg=black;bg=yellow', ' ', true);
     }
 
     /**


### PR DESCRIPTION
The coloring of warning messages is 'fg=white;bg=yellow', i.e. white foreground on yellow background - hardly visible.

This PR changes that to black foreground on yellow background.