### PR TITLE
Enhance ShellProcess

### DIFF
--- a/src/Utils/ShellProcess.php
+++ b/src/Utils/ShellProcess.php
@@ -3,6 +3,7 @@ namespace Drupal\Console\Core\Utils;
 
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Drupal\Console\Core\Style\DrupalStyle;
@@ -51,6 +52,28 @@ class ShellProcess
     }
 
     /**
+     * Finds an executable by name.
+     *
+     * Uses the ExecutableFinder Symfony component, adding the
+     * [appRoot]/vendor/bin directory to the searchable ones for the case where
+     * the local bin is not set in the PATH environment variable.
+     *
+     * @param string      $name      The executable name (without the
+     *                               extension).
+     * @param string|null $default   The default to return if no executable is
+     *                               found.
+     * @param array       $extraDirs Additional dirs to check into.
+     *
+     * @return string|null The executable path or default value
+     */
+    public function findExecutable($name, $default = null, array $extraDirs = [])
+    {
+        $finder = new ExecutableFinder();
+        $extraDirs[] = $this->appRoot . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'bin';
+        return $finder->find($name, $default, $extraDirs);
+    }
+
+    /**
      * @param string $command
      * @param string $workingDirectory
      *
@@ -58,30 +81,33 @@ class ShellProcess
      *
      * @return Process
      */
-    public function exec($command, $workingDirectory=null)
+    public function exec($command, $workingDirectory = null)
     {
-        if (!$workingDirectory || $workingDirectory==='') {
+        if (!$workingDirectory || $workingDirectory === '') {
             $workingDirectory = $this->appRoot;
         }
 
-        if (realpath($workingDirectory)) {
-            $this->io->comment(
-                $this->translator->trans('commands.exec.messages.working-directory') .': ',
-                false
-            );
-            $this->io->writeln(realpath($workingDirectory));
-        }
-
-        $this->io->comment(
-            $this->translator->trans('commands.exec.messages.executing-command') .': ',
-            false
-        );
-        $this->io->writeln($command);
-
+        // Prepare the process.
         $this->process = new Process($command);
         $this->process->setWorkingDirectory($workingDirectory);
         $this->process->enableOutput();
         $this->process->setTimeout(null);
+
+        // Inform about context.
+        if (realpath($workingDirectory)) {
+            $this->io->comment(
+                $this->translator->trans('commands.exec.messages.working-directory') . ': ',
+                false
+            );
+            $this->io->writeln(realpath($workingDirectory));
+        }
+        $this->io->comment(
+            $this->translator->trans('commands.exec.messages.executing-command') . ': ',
+            false
+        );
+        $this->io->writeln(is_array($command) ? implode(' ', $command) : $command);
+
+        // Run the process.
         $this->process->run(
             function ($type, $buffer) {
                 $this->io->write($buffer);
@@ -92,6 +118,62 @@ class ShellProcess
             throw new ProcessFailedException($this->process);
         }
 
+        return $this->process->isSuccessful();
+    }
+
+    /**
+     * Executes a subprocess in TTY mode, if possible.
+     *
+     * @param string $command
+     * @param bool $fallbackAllowed
+     *   (Optional) If TTY is not possible, and this is set to TRUE, falls back
+     *   to running as a non-interactive process, calling ::exec().
+     * @param string $workingDirectory
+     *
+     * @return bool
+     *   TRUE if the process run successfully, FALSE otherwise.
+     */
+    public function execTty($command, $fallbackAllowed = false, $workingDirectory = null)
+    {
+        if (!$workingDirectory || $workingDirectory === '') {
+            $workingDirectory = $this->appRoot;
+        }
+
+        // Prepare the process.
+        $this->process = new Process($command);
+        $this->process->setWorkingDirectory($workingDirectory);
+        $this->process->setTimeout(null);
+
+        // Try running the process as a TTY one, i.e. allowing user
+        // interaction.
+        try {
+            $this->process->setTty(true);
+        } catch(\RuntimeException $e) {
+            // If fallback is allowed then try to run as a non-interactive
+            // process.
+            if ($fallbackAllowed) {
+                return $this->exec($command, $workingDirectory);
+            } else {
+                $this->getIo()->error($e->getMessage());
+            }
+        }
+
+        // Inform about context.
+        if (realpath($workingDirectory)) {
+            $this->io->comment(
+                $this->translator->trans('commands.exec.messages.working-directory') . ': ',
+                false
+            );
+            $this->io->writeln(realpath($workingDirectory));
+        }
+        $this->io->comment(
+            $this->translator->trans('commands.exec.messages.executing-command') . ': ',
+            false
+        );
+        $this->io->writeln(is_array($command) ? implode(' ', $command) : $command);
+
+        // Run the process.
+        $this->process->run();
         return $this->process->isSuccessful();
     }
 


### PR DESCRIPTION
@enzolutions this is a preliminary PR while working on https://github.com/hechoendrupal/drupal-console/issues/4180 

We need to enhance ShellProcess to be able to
a) find the executable of 'composer' before running `composer require` or `composer update`
b) execute the composer processes in TTY mode, the current `::exec` method is not enough

In this PR I am proposing to introduce a `::findExecutable` and a `::execTty` methods.

A PR for https://github.com/hechoendrupal/drupal-console/issues/4180 will follow in the next few days in the hechoendrupal/drupal-console repo.