### PR TITLE
#391 Updated dflydev/dot-access-configuration version scope to include 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require": {
         "php": ">=7.0.8",
-        "dflydev/dot-access-configuration": "^1.0.4",
+        "dflydev/dot-access-configuration": "^1.0.4 || ^2.0",
         "drupal/console-en": "1.9.7",
         "stecman/symfony-console-completion": "~0.7",
         "symfony/config": "~3.0|^4.4",
@@ -68,12 +68,6 @@
         ],
         "psr-4": {
             "Drupal\\Console\\Core\\": "src"
-        }
-    },
-    "repositories": {
-        "dot-access-configuration": {
-            "url": "https://github.com/LOBsTerr/dflydev-dot-access-configuration.git",
-            "type": "git"
         }
     }
 }


### PR DESCRIPTION
Fixes #391 

Updating the version scope of the `dflydev/dflydev-dot-access-configuration` package to allow [the new 2.0 release](https://github.com/dflydev/dflydev-dot-access-configuration/releases/tag/v2.0.0) which fixes an issue reported in #391.

Also, there is no need to reference a fork of the repository anymore, so it was removed from the composer file.
